### PR TITLE
Added route rewrites in PocketBase; Created Admin Setup in vue-client

### DIFF
--- a/pocket-base/go.mod
+++ b/pocket-base/go.mod
@@ -9,6 +9,11 @@ require (
 )
 
 require (
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible // indirect
+	github.com/labstack/gommon v0.4.0 // indirect
+)
+
+require (
 	github.com/AlecAivazis/survey/v2 v2.3.6 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/aws/aws-sdk-go v1.44.187 // indirect
@@ -47,6 +52,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/labstack/echo v3.3.10+incompatible
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/mattn/go-sqlite3 v1.14.16 // indirect

--- a/pocket-base/go.sum
+++ b/pocket-base/go.sum
@@ -786,6 +786,7 @@ github.com/dennwc/varint v1.0.0/go.mod h1:hnItb35rvZvJrbTALZtY/iQfDs48JKRG1RPpgz
 github.com/denverdino/aliyungo v0.0.0-20190125010748-a747050bb1ba/go.mod h1:dV8lFg6daOBZbT6/BDGIz6Y3WFGn8juu6G+CQ6LHtl0=
 github.com/devigned/tab v0.1.1/go.mod h1:XG9mPq0dFghrYvoBF3xdRrJzSTX1b7IQrvaL9mzjeJY=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dgryski/go-sip13 v0.0.0-20200911182023-62edffca9245/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -1339,8 +1340,12 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/labstack/echo v3.3.10+incompatible h1:pGRcYk231ExFAyoAjAfD85kQzRJCRI8bbnE7CX5OEgg=
+github.com/labstack/echo v3.3.10+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
 github.com/labstack/echo/v5 v5.0.0-20220201181537-ed2888cfa198 h1:lFz33AOOXwTpqOiHvrN8nmTdkxSfuNLHLPjgQ1muPpU=
 github.com/labstack/echo/v5 v5.0.0-20220201181537-ed2888cfa198/go.mod h1:uh3YlzsEJj7OG57rDWj6c3WEkOF1ZHGBQkDuUZw3rE8=
+github.com/labstack/gommon v0.4.0 h1:y7cvthEAEbU0yHOf4axH8ZG2NH8knB9iNSoTO8dyIk8=
+github.com/labstack/gommon v0.4.0/go.mod h1:uW6kP17uPlLJsD3ijUYn3/M5bAxtlZhMI6m3MFxTMTM=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
@@ -1373,6 +1378,7 @@ github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
@@ -1744,6 +1750,7 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
+github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQD0Loo=
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
@@ -2220,6 +2227,7 @@ golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211103235746-7861aae1554b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/vue-client/src/components/auth/SetupAdminForm.vue
+++ b/vue-client/src/components/auth/SetupAdminForm.vue
@@ -1,0 +1,66 @@
+<template>
+  <v-container>
+    <v-row class="pt-12" justify="center">
+      <v-col cols="12" sm="12" md="8">
+        <v-card variant="tonal">
+          <v-card-title>
+            <span class="headline">Setup</span>
+          </v-card-title>
+          <v-card-text class="pb-0">
+            <v-form ref="form" v-model="valid" lazy-validation>
+              <v-text-field v-model="appStore.adminUserSetup.email" label="E-mail" required
+                :rules="[rules.required, rules.email]"></v-text-field>
+              <v-text-field v-model="appStore.adminUserSetup.password"
+                :append-icon="showPassword ? 'mdi-eye' : 'mdi-eye-off'" :type="showPassword ? 'text' : 'password'"
+                label="Password" hint="At least 10 characters" counter required
+                @click:append="showPassword = !showPassword" :rules="[rules.min]"></v-text-field>
+              <v-text-field v-model="appStore.adminUserSetup.passwordConfirm"
+                :append-icon="showConfirmPassword ? 'mdi-eye' : 'mdi-eye-off'"
+                :type="showConfirmPassword ? 'text' : 'password'" label="Confirm Password" hint="At least 10 characters"
+                counter required @click:append="showConfirmPassword = !showConfirmPassword"
+                :rules="[rules.min, rules.passwordMatch]"></v-text-field>
+            </v-form>
+          </v-card-text>
+          <div class="pb-6 px-6">
+            <v-btn size="x-large" variant="tonal" :disabled="!valid" color="success" @click="setup" block>
+              Setup
+            </v-btn>
+          </div>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useAppStore } from '@/store/app';
+import router from '@/router';
+
+const appStore = useAppStore()
+
+const rules = {
+  required: (v: string) => !!v || 'Required.',
+  min: (v: string) => v.length >= 10 || 'At least 10 characters',
+  passwordMatch: () => (appStore.adminUserSetup.passwordConfirm === appStore.adminUserSetup.password) || 'Passwords must match',
+  email: (v: string) => /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/.test(v) || 'E-mail must be valid',
+};
+
+const valid = ref(false);
+const showPassword = ref(false);
+const showConfirmPassword = ref(false);
+
+async function setup() {
+  try {
+    const registerSuccess = await appStore.registerAdmin()
+    if (registerSuccess) {
+      router.push('/')
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      router.push('/n/error?msg=' + error.message)
+    }
+  }
+}
+
+</script>

--- a/vue-client/src/layouts/default/Default.vue
+++ b/vue-client/src/layouts/default/Default.vue
@@ -9,6 +9,18 @@
 import { useAppStore } from '@/store/app';
 import DefaultAppBar from './AppBar.vue'
 import DefaultView from './View.vue'
+import router from '@/router';
 
 const appStore = useAppStore()
+
+try {
+  await appStore.checkIsSetup()
+  if (!appStore.appSettings.isSetup) {
+    router.push('/admin/setup-admin')
+  }
+} catch (error) {
+  if (error instanceof Error) {
+    router.push('/n/error?msg=' + error.message)
+  }
+}
 </script>

--- a/vue-client/src/router/index.ts
+++ b/vue-client/src/router/index.ts
@@ -24,9 +24,26 @@ const routes = [
         path: '/contact',
         name: 'Contact',
         component: () => import(/* webpackChunkName: "contact" */ '@/views/Contact.vue'),
-      }
+      },
+      {
+        path: '/admin',
+        component: () => import('@/App.vue'),
+        children: [
+          {
+            path: '/admin/setup-admin',
+            name: 'SetupAdmin',
+            component: () => import('@/views/admin/SetupAdmin.vue'),
+          },
+        ]
+      },
     ],
   },
+  {
+    path: '/:pathMatch(.*)*',
+    redirect: '/home',
+    // name: 'NotFound',
+    // component: () => import('@/views/NotFound.vue'),
+  }
 ]
 
 const router = createRouter({

--- a/vue-client/src/store/app.ts
+++ b/vue-client/src/store/app.ts
@@ -1,14 +1,65 @@
 // Utilities
-import { defineStore } from 'pinia'
-import { ref } from 'vue'
-import { useLocalStorage } from '@vueuse/core'
+import { defineStore } from "pinia";
+import { ref, inject } from "vue";
+import { useLocalStorage } from "@vueuse/core";
+import { pocketBaseSymbol } from "@/pocketbase/injectionSymbols";
 
-export const useAppStore = defineStore('app', () => {
 
-  const appSettings = ref(useLocalStorage('appSettings', {
-    theme: 'dark',
-    name: 'PocketBase Vue Starter',
-  }))
 
-  return { appSettings }
-})
+export const useAppStore = defineStore("app", () => {
+  const adminUserSetup = ref({
+    email: '',
+    password: '',
+    passwordConfirm: '',
+  });
+
+  const appSettings = ref(
+    useLocalStorage("appSettings", {
+      theme: "dark",
+      name: "PocketBase Vue Starter",
+      isSetup: false,
+    })
+  );
+
+  // Actions
+  // done for initial PocketBase setup
+  const pb = inject(pocketBaseSymbol);
+  const checkIsSetup = async () => {
+    if (!appSettings.value.isSetup) {
+      try {
+        const initCheck = await pb?.send("/api/init-check", {});
+        appSettings.value.isSetup = initCheck.isSetup;
+      } catch (e) {
+        appSettings.value.isSetup = false;
+        throw new Error(
+          "Something whent wrong with processing the request. " +
+            "Please make sure that PocketBase is running and that the API is accessible."
+        );
+      }
+    }
+  };
+
+  const registerAdmin = async () => {
+    try {
+      const register = await pb?.send("/api/admins", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: adminUserSetup.value,
+      });
+      console.log(register.email);
+      if (register.email === adminUserSetup.value.email) {
+        appSettings.value.isSetup = true;
+        return true;
+      }
+    } catch (e) {
+      throw new Error(
+        "Something whent wrong with processing the request. " +
+          "Please make sure that PocketBase is running and that the API is accessible."
+      );
+    }
+  };
+
+  return { adminUserSetup, appSettings, checkIsSetup, registerAdmin };
+});

--- a/vue-client/src/views/admin/SetupAdmin.vue
+++ b/vue-client/src/views/admin/SetupAdmin.vue
@@ -1,0 +1,15 @@
+<template>
+  <SetupAdminForm />
+</template>
+
+<script setup lang="ts">
+import SetupAdminForm from '@/components/auth/SetupAdminForm.vue';
+import { useAppStore } from '@/store/app';
+import router from '@/router';
+
+const appStore = useAppStore()
+
+if(appStore.appSettings.isSetup) {
+  router.push('/')
+}
+</script>


### PR DESCRIPTION
This adds the following:

- Route rewrites in PocketBase to not access the installer page for initial admin setup
- Added AdminSetup page in vue-client to set the initial PocketBase Admin
- Vue added a not found route to redirect to /home for now